### PR TITLE
[codex] Pass Pulse database URL to app

### DIFF
--- a/manifests/hb-pulse/RUNBOOK.md
+++ b/manifests/hb-pulse/RUNBOOK.md
@@ -101,6 +101,13 @@ $SSH 'cd ~/heartbeat && git pull origin main'
 
 `session-secret`, `db-password`, `google-client-id`, `google-client-secret`, `vapid-public-key`, `vapid-private-key`, `smtp-pass`, `cloudflare-tunnel-token`
 
+## Database Secrets
+
+`db-password` is stored in Key Vault and exported as `DB_PASSWORD` by `deploy.sh`.
+The Postgres service receives it as `POSTGRES_PASSWORD`. The Pulse app service does
+not receive `DB_PASSWORD`; `deploy.sh` builds `DATABASE_URL` from the password and
+passes that connection string to the app.
+
 ## Coexisting Services
 
 The living-life quiz runs on the same VM on port 3000. Its manifests are at `~/heartbeat/manifests/living-life-quiz/` and secrets at `/secrets/`.

--- a/manifests/hb-pulse/deploy.sh
+++ b/manifests/hb-pulse/deploy.sh
@@ -39,18 +39,19 @@ if [[ ! -d "$SECRETS_DIR" ]]; then
 fi
 
 log "Reading secrets from Key Vault..."
-export DB_PASSWORD=$(sudo cat $SECRETS_DIR/db-password)
-export SESSION_SECRET=$(sudo cat $SECRETS_DIR/session-secret)
-export GOOGLE_CLIENT_ID=$(sudo cat $SECRETS_DIR/google-client-id)
-export GOOGLE_CLIENT_SECRET=$(sudo cat $SECRETS_DIR/google-client-secret)
-export VAPID_PUBLIC_KEY=$(sudo cat $SECRETS_DIR/vapid-public-key)
-export VAPID_PRIVATE_KEY=$(sudo cat $SECRETS_DIR/vapid-private-key)
-export SMTP_PASS=$(sudo cat $SECRETS_DIR/smtp-pass)
-export TUNNEL_TOKEN=$(sudo cat $SECRETS_DIR/cloudflare-tunnel-token)
+export DB_PASSWORD=$(sudo cat "$SECRETS_DIR/db-password")
+export DATABASE_URL="postgresql://pulse:${DB_PASSWORD}@pulse-db:5432/pulse"
+export SESSION_SECRET=$(sudo cat "$SECRETS_DIR/session-secret")
+export GOOGLE_CLIENT_ID=$(sudo cat "$SECRETS_DIR/google-client-id")
+export GOOGLE_CLIENT_SECRET=$(sudo cat "$SECRETS_DIR/google-client-secret")
+export VAPID_PUBLIC_KEY=$(sudo cat "$SECRETS_DIR/vapid-public-key")
+export VAPID_PRIVATE_KEY=$(sudo cat "$SECRETS_DIR/vapid-private-key")
+export SMTP_PASS=$(sudo cat "$SECRETS_DIR/smtp-pass")
+export TUNNEL_TOKEN=$(sudo cat "$SECRETS_DIR/cloudflare-tunnel-token")
 export ADMIN_EMAIL="charles@heartbeatchurch.com.au"
 
 # Verify all secrets were read
-for var in DB_PASSWORD SESSION_SECRET GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET \
+for var in DB_PASSWORD DATABASE_URL SESSION_SECRET GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET \
            VAPID_PUBLIC_KEY VAPID_PRIVATE_KEY SMTP_PASS TUNNEL_TOKEN; do
     if [[ -z "${!var}" ]]; then
         error "Failed to read secret for $var"

--- a/manifests/hb-pulse/docker-compose.yml
+++ b/manifests/hb-pulse/docker-compose.yml
@@ -31,8 +31,7 @@ services:
     volumes:
       - /data/hb-pulse/uploads:/data/uploads
     environment:
-      - DB_PASSWORD=${DB_PASSWORD}
-      - DATABASE_URL=postgresql://pulse:${DB_PASSWORD}@pulse-db:5432/pulse
+      - DATABASE_URL=${DATABASE_URL}
       - SESSION_SECRET=${SESSION_SECRET}
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}


### PR DESCRIPTION
## Summary

- Export `DATABASE_URL` in the HB-Pulse deploy script from the existing Key Vault `db-password` secret.
- Pass only `DATABASE_URL` into the Pulse app service.
- Keep `DB_PASSWORD` for the Postgres service as `POSTGRES_PASSWORD`.
- Update the runbook to document the split between database password and app connection string.

## Why

The app image should validate and consume its complete database connection string instead of requiring the raw database password as a separate runtime environment variable. Postgres still needs the password secret, but the app container no longer does.

## Companion PR

- hb-pulse app PR: https://github.com/charlesverdad/hb-pulse/pull/251

## Validation

- `bash -n manifests/hb-pulse/deploy.sh`
- `docker compose -f manifests/hb-pulse/docker-compose.yml config` with dummy environment values; confirmed `pulse` receives `DATABASE_URL` and `pulse-db` receives `POSTGRES_PASSWORD`
