### PR TITLE
Refine sermon blog excerpt guidance to be hook-first

### DIFF
--- a/.claude/LEARNINGS.md
+++ b/.claude/LEARNINGS.md
@@ -1,0 +1,14 @@
+# Learnings
+
+## Sermon blog pipeline (2026-07-24 batch run)
+
+- **Camp / special-event streams live on the Gold Coast channel** (`@heartbeatgoldcoast2173/streams`), not the main `@HeartbeatChurch` channel. If a Sunday has no stream on the main channel, check there before concluding no service happened.
+- **A "5-min read" = 1,000-1,250 words** (user-defined). Give writer subagents a hard cap; drafts at the older 1200-1800 target will need trimming.
+- **`ghost-list-posts.mjs` only lists published posts.** To check for existing drafts, copy it and change the filter `status:published` → `status:draft`. Always check drafts before creating posts (use `ghost-publish.mjs --updateId <id>` to update in place).
+- **Camp session numbering ≠ sermon numbering.** QLD camp 2026 had 4 sessions but only 3 sermons (Session 2 was prayer pathways). In posts, refer to "Saturday night's message" rather than "session N" to avoid clashing with YouTube video titles. Session 3 was split across two videos (worship video first, sermon video second) — embed the sermon video.
+- **Pastor Josh's daughter is "Sky"** (not Skye) — matches published posts. She and PM were commissioned as full shepherds on 2026-07-12.
+- **`ghost-publish.mjs` cannot change the slug.** There is no `--slug` flag, and Ghost keeps the existing slug on `--updateId`. If the title changes after the draft is created, the slug stays stale and must be edited by hand in the Ghost editor's post settings. Settle the title before the first publish to avoid this.
+- **Excerpts must not use AI teaser phrasing.** "lands closer to home", "the answer might surprise you", "what he said next" and friends were explicitly rejected. State the actual substance instead of promising a payoff. `/codex:rescue` is a good second ear for both excerpts and full-body deglazing — Codex catches contrast formulas ("not X, but Y") and uniform paragraph rhythm that the deglaze skill leaves behind.
+- **A sermon that continues a previous week's message needs re-angling, not re-summarising.** The 2026-07-26 service finished the camp's "You Are Full" message, so the already-published post covered its first half. Check the prior post's beats and build the new one on the fresh material only.
+- **Pastor Josh rarely announces a sermon title.** Look for the declaration he has the congregation repeat to each other, usually near the closing prayer — that line is the intended takeaway and makes the best title.
+- **Effective batch flow:** transcribe strictly sequentially (Whisper saturates the machine), but run writer/deglaze subagents in parallel — they're not CPU-bound. Chain per post: write (fresh from transcript, never from old draft) → discrete deglaze pass → Ghost draft. Finish with a single cross-post cohesion pass (series threading, repeated hooks, names, word caps) and re-push only edited posts.

--- a/.claude/commands/sermon-blog-generate.md
+++ b/.claude/commands/sermon-blog-generate.md
@@ -126,7 +126,11 @@ Follow the structure of existing Heartbeat Church blog posts:
 
 From the blog post and transcript, determine:
 - **Title**: The sermon title. The speaker usually states it near the beginning. If unclear, create a short (6-10 word) title from the main theme. No clickbait.
-- **Excerpt**: A short, punchy summary (~150 characters max) suitable for a post card/preview. State the core idea directly. No teaser-style listings ("took us through X, Y, and Z"), no literary flourishes or em-dashes. Think tweet-length.
+- **Excerpt**: ~150 characters, tweet-length. **Lead with a hook**, then land the sermon. The first sentence should be a provocative question or a sharp, counterintuitive claim pulled from the sermon's central tension — something that creates curiosity. Only *after* the hook, name the speaker, the passage, and the turn the sermon takes (often a single key word revealed after a colon). Do NOT open with admin like "<Speaker> closes/opens the series in <book>", and do NOT end on a flat three-item summary ("the gospel changes our identity, our relationships, and how we read circumstances") — that reads as a table of contents, not a hook. No em-dashes.
+  - Good: "What does God's silence actually mean? Kevin Shin opens Matthew 7 with three answers worth knowing: yes, no, and the hardest one. Wait."
+  - Good: "You can tick every box and still feel hungry. Jason Lim opens Matthew 7 with the word that changes the question: satisfaction."
+  - Good: "Sabbath came before work, not after it. Pastor Josh on rest as identity, the lie of productivity, and why we are creatures of appreciation."
+  - Weak (avoid): "Pastor Josh closes the Celebrating Work series in Philemon: the gospel rewrites our identity, our relationships, and how we read every hard circumstance."
 - **Keywords**: 3 topic keywords for potential image search (e.g. "faith", "community", "prayer").
 
 ### 5. Save the output

--- a/.claude/commands/sermon-to-blog.md
+++ b/.claude/commands/sermon-to-blog.md
@@ -82,6 +82,7 @@ Follow the same process as the `sermon-blog-generate` skill:
      - **YouTube embed** with `?start=` parameter near the top
      - Preserve the speaker's analogies, stories, humor, and challenging thoughts
      - NO hallucinated quotes, theology, or Bible references
+     - **Excerpt (~150 chars): hook-first.** Open with a provocative question or sharp, counterintuitive claim from the sermon's core tension, THEN name the speaker/passage/turn (often a key word after a colon). Don't open with "<Speaker> closes/opens the series" and don't end on a flat three-item summary. See the excerpt examples in the `sermon-blog-generate` skill.
 
 3. **Run the `deglaze` skill on the subagent output before saving.** The deglaze skill (located at `~/work/custom-skills/skills/deglaze/SKILL.md`) strips AI-generated writing patterns — em dash overuse, template phrases, copula avoidance, "It's not X, it's Y" constructions, hollow intensifiers, formulaic openings, etc. Run it in `rewrite` mode with `blog` profile against the generated HTML body. Take the **rewritten version** from its output and use that as the final HTML. This step makes the post sound more natural and human, not like AI-generated prose. Skip only the YouTube embed block (the iframe is exempt).
 


### PR DESCRIPTION
## Summary

Prompt/skill refinements for the sermon-to-blog pipeline, plus a learnings file. No infra or app code.

- **`sermon-blog-generate.md`** — rewrite the Excerpt spec: lead with a hook (provocative question / counterintuitive claim from the sermon's core tension), *then* name speaker, passage, and the turn. Adds worked good/weak examples; bans "`<Speaker>` closes/opens the series" openers and flat three-item-summary endings.
- **`sermon-to-blog.md`** — mirror the hook-first excerpt rule and reference the examples in `sermon-blog-generate`.
- **`.claude/LEARNINGS.md`** — captures sermon-pipeline learnings for future runs.

## Test plan

Documentation/prompt-only change — nothing to build or run. Effect is validated on the next sermon blog generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KRNU49HV7DZgWzFgqWYo4w